### PR TITLE
Pass allContent prop to Archive component.

### DIFF
--- a/layouts/content/pages.svelte
+++ b/layouts/content/pages.svelte
@@ -9,11 +9,11 @@
 </script>
 
 <section class="isMarginAutoCentered">
-
+  
   <h1>{ page }</h1>
 
   {#if page === "archive" }
-    <Archive />
+    <Archive allContent />
   {/if}
 
   {#if page === "search" }


### PR DESCRIPTION
Should fix:

<details>
<summary>Error</summary>

```
2021/04/05 18:29:15 errs.go:55: Can't render htmlComponent: TypeError: Cannot read property 'length' of undefined plenti/cmd/build/data_source.go on line 322

javascript stack trace: TypeError: Cannot read property 'length' of undefined
    at each (create_ssr:1334:31)
    at create_ssr:11:9
    at Object.$$render (create_ssr:1369:22)
    at create_ssr:34:98
    at Object.$$render (create_ssr:1369:22)
    at create_ssr:34:121
    at $$render (create_ssr:1369:22)
    at Object.render (create_ssr:1377:26)
    at create_ssr:1:58
```

</details>

It seems like the issue was that the `allContent` prop was not getting passed down to a child component that was trying to use it. The error message wasn't very clear, so it was tricky to debug! We're hoping to make these error messages better in future!