### PR TITLE
Update head.svelte

### DIFF
--- a/layouts/global/head.svelte
+++ b/layouts/global/head.svelte
@@ -21,5 +21,5 @@
   <link rel='stylesheet' href='/assets/css/skeleton.css'>
   <link rel='stylesheet' href='/assets/css/extended.css'>
 
-  <link rel='stylesheet' href='spa/bundle.css'>
+  <link rel='stylesheet' href='/spa/bundle.css'>
 </head>


### PR DESCRIPTION
We added a baseurl option (https://github.com/plentico/plenti/issues/68) in [v0.4.24](https://github.com/plentico/plenti/releases/tag/v0.4.24) in order to let folks serve their sites from a subfolder, like https://example.com/mysite. We get that to work using a `<base>` element in the `<head>` which you can safely remove if you don't want to use subfolders (I saw you commented it out). However, if you want to use it, all the URLs should be relative, e.g. not starting with a forward slash. Because of that, we removed all the forward slashes in the default starter so if you converted those back, this one might just have gotten missed. So on the internal blog pages it was trying to load the stylesheet from a path relative to the current page. I should definitely add info about this to our docs! 